### PR TITLE
fix: enable chest sprite buffer in Booster Pass room

### DIFF
--- a/randomizer/data/rooms/room_101.py
+++ b/randomizer/data/rooms/room_101.py
@@ -13,8 +13,8 @@ from ..variables.action_script_names import *
 room = Room(
     partition=Partition(
         ally_sprite_buffer_size=1,
-        allow_extra_sprite_buffer=False,
-        extra_sprite_buffer_size=0,
+        allow_extra_sprite_buffer=True,
+        extra_sprite_buffer_size=1,
         buffers = [
             Buffer(
                 buffer_type=BufferType.EMPTY_3,


### PR DESCRIPTION
## Summary
- enable the extra sprite buffer for Booster Pass Area 02
- allow the yellow chest object to coexist with the other room objects without corrupting chest rewards

## Testing
- python3 -m py_compile randomizer/data/rooms/room_101.py
- git diff --check

Fixes #66